### PR TITLE
Config: what cap events send hipchat messages.

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -10,7 +10,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
 
     task :trigger_notification do
-      set :hipchat_send_notification, true
+      set :hipchat_send_notification, fetch(:hipchat_events, %w(start finished)).include?('start')
     end
 
     task :configure_for_migrations do


### PR DESCRIPTION
Set an array of events to hipchat_events capistrano variable with either start/finish.  

Setting just finish allows disabling start deploy messages.

To disable deploy start message:
`set :hipchat_events, %w(finished)`
